### PR TITLE
fix No host IP was given to the Vagrant core NFS helper

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,7 @@ Vagrant.configure(2) do |config|
       node.vm.provision "shell", path: "scripts/provision_cassandra.sh", args: "#{UNIQUE_ID}"
     
       node.vm.provider :digital_ocean do |provider, override|
+        override.nfs.functional = false
         override.ssh.private_key_path = 'id_rsa'
         override.vm.box = 'digital_ocean'
         override.vm.box_url = "https://github.com/devopsgroup-io/vagrant-digitalocean/raw/master/box/digital_ocean.box"


### PR DESCRIPTION
env: Vagrant 2.0.1
Got error `No host IP was given to the Vagrant core NFS helper`.  Resolved the issue according to https://github.com/hashicorp/vagrant/issues/5401